### PR TITLE
ページネーション

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,18 +12,19 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'webpacker'
 
-# ビュー
+# 日本語化
 gem 'enum_help'
 gem 'rails-i18n'
 # 機能
+gem 'pagy', '~> 3.5'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'config'
 gem 'sorcery', '>= 0.15.0'
-# cron
+# 定期実行
 gem 'redis-namespace'
 gem 'sidekiq', '~> 5.0'
 gem 'whenever', require: false
-# api
+# 外部API
 gem 'twitter'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pagy (3.8.1)
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
@@ -387,6 +388,7 @@ DEPENDENCIES
   factory_bot_rails (~> 5.1, >= 5.1.1)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
+  pagy (~> 3.5)
   pry-byebug (~> 3.9)
   pry-rails
   puma (~> 3.11)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::BaseController < ApplicationController
   include Pagy::Backend
-  after_action :set_pagy_header if @pagy
+  after_action :set_pagy_header, if: -> { @pagy }
   rescue_from Twitter::Error::TooManyRequests, with: :rescue_limited_twitter_requests
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_not_found
   # rescue_from ActionController::RoutingError, with: :rescue_not_found

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -3,6 +3,7 @@ require 'pagy/extras/headers'
 class Api::V1::BaseController < ApplicationController
   include Pagy::Backend
   after_action :set_pagy_header, if: -> { @pagy }
+
   rescue_from Twitter::Error::TooManyRequests, with: :rescue_limited_twitter_requests
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_not_found
   # rescue_from ActionController::RoutingError, with: :rescue_not_found

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,3 +1,5 @@
+require 'pagy/extras/headers'
+
 class Api::V1::BaseController < ApplicationController
   include Pagy::Backend
   after_action :set_pagy_header, if: -> { @pagy }

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::BaseController < ApplicationController
+  include Pagy::Backend
+  after_action :set_pagy_header if @pagy
   rescue_from Twitter::Error::TooManyRequests, with: :rescue_limited_twitter_requests
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_not_found
   # rescue_from ActionController::RoutingError, with: :rescue_not_found
@@ -8,6 +10,11 @@ class Api::V1::BaseController < ApplicationController
   # end
 
   protected
+
+  def set_pagy_header
+    pagy_headers_merge(@pagy)
+    response.headers.merge!({ 'Request-Url' => request.url.sub(/\?page=\d+$/, '') })
+  end
 
   def rescue_limited_twitter_requests
     error_json = {

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::BaseController < ApplicationController
 
   def set_pagy_header
     pagy_headers_merge(@pagy)
-    response.headers.merge!({ 'Request-Url' => request.url.sub(/\?page=\d+$/, '') })
+    response.headers.merge!({ 'Request-Url' => request.path_info })
   end
 
   def rescue_limited_twitter_requests

--- a/app/controllers/api/v1/registered_tags_controller.rb
+++ b/app/controllers/api/v1/registered_tags_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::RegisteredTagsController < Api::V1::BaseController
 
   def index
     registered_tags = RegisteredTag.by_user(params[:user_uuid]).asc.includes(:tag, :tweets)
+    @pagy, registered_tags = pagy(registered_tags)
     render json: registered_tags
   end
 

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TagsController < Api::V1::BaseController
   def index
-    tags = Tag.all
+    @pagy, tags = pagy(Tag.all)
     render json: tags
   end
 end

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -1,7 +1,12 @@
+require 'pagy/extras/headers'
+
 class Api::V1::TweetsController < Api::V1::BaseController
+  include Pagy::Backend
+
   def index
     registered_tag = RegisteredTag.find(params[:registered_tag_id])
-    tweets = registered_tag.tweets.desc
+    pagy, tweets = pagy(registered_tag.tweets.desc)
+    pagy_headers_merge(pagy)
     render json: tweets
   end
 

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -1,9 +1,7 @@
-require 'pagy/extras/headers'
-
 class Api::V1::TweetsController < Api::V1::BaseController
   def index
     registered_tag = RegisteredTag.find(params[:registered_tag_id])
-    @pagy, tweets = pagy(registered_tag.tweets.desc)
+    @pagy, tweets = pagy(registered_tag.tweets.desc, items: 10)
     render json: tweets
   end
 

--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -1,12 +1,9 @@
 require 'pagy/extras/headers'
 
 class Api::V1::TweetsController < Api::V1::BaseController
-  include Pagy::Backend
-
   def index
     registered_tag = RegisteredTag.find(params[:registered_tag_id])
-    pagy, tweets = pagy(registered_tag.tweets.desc)
-    pagy_headers_merge(pagy)
+    @pagy, tweets = pagy(registered_tag.tweets.desc)
     render json: tweets
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < Api::V1::BaseController
-  before_action :require_login
+  before_action :require_login, only: %i[update destroy current]
 
   def index
     @pagy, users = pagy(User.all)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::UsersController < Api::V1::BaseController
-  before_action :require_login, only: %i[current update destroy]
+  before_action :require_login
 
   def index
-    users = User.all
+    @pagy, users = pagy(User.all)
     render json: users
   end
 

--- a/app/javascript/components/shared/TheHeader.vue
+++ b/app/javascript/components/shared/TheHeader.vue
@@ -1,10 +1,5 @@
 <template>
-  <v-app-bar
-    app
-    flat
-    dark
-    src="https://cdn.vuetifyjs.com/images/backgrounds/vbanner.jpg"
-  >
+  <v-app-bar app flat dark src="https://cdn.vuetifyjs.com/images/backgrounds/vbanner.jpg">
     <v-toolbar-title>Hashlog</v-toolbar-title>
     <v-spacer />
     <v-toolbar-items>
@@ -19,9 +14,12 @@
 export default {
   methods: {
     logout() {
-      this.$axios.delete("/api/v1/logout", {}).then(response => {
+      try {
+        this.$axios.delete("/api/v1/logout", {})
         this.$router.push({ name: "top" })
-      })
+      } catch (error) {
+        console.log(error)
+      }
     }
   }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,8 +16,8 @@ import VueAxiosPlugin from "../plugins/vue-axios"
 Vue.use(VueAxiosPlugin, { axios: Axios })
 Vue.prototype.$axios = Axios
 
-import titlePlugin from "../plugins/page-title"
-Vue.mixin(titlePlugin)
+import customPlugin from "../plugins/custom-plugins"
+Vue.mixin(customPlugin)
 import dayjs from "../plugins/dayjs"
 Vue.mixin(dayjs)
 import veeValidate from "../plugins/vee-validate"

--- a/app/javascript/pages/Tag.vue
+++ b/app/javascript/pages/Tag.vue
@@ -16,6 +16,9 @@
         <tweets :tweets="tweets" :user="user" />
       </v-col>
     </v-container>
+    <div class="text-center">
+      <v-pagination v-model="page.currentPage" :length="page.totalPages" :total-visible="7"></v-pagination>
+    </div>
     <delete-dialog ref="deleteDialog" @push-delete="deleteTag">
       保存されていたツイートのデータが
       <br />全て消えてしまいます。
@@ -38,6 +41,11 @@ export default {
   },
   data() {
     return {
+      page: {
+        currentPage: 1,
+        totalPages: 1,
+        requestUrl: ""
+      },
       user: {
         uuid: "",
         name: "",
@@ -99,6 +107,7 @@ export default {
         const tweetsRes = await this.$axios.get(
           `/api/v1/registered_tags/${registeredTag.id}/tweets`
         )
+        this.setPageData(tweetsRes)
         const { tweets } = tweetsRes.data
         this.tweets = tweets
       } catch (error) {

--- a/app/javascript/pages/Tag.vue
+++ b/app/javascript/pages/Tag.vue
@@ -17,7 +17,12 @@
       </v-col>
     </v-container>
     <div class="text-center">
-      <v-pagination v-model="page.currentPage" :length="page.totalPages" :total-visible="7"></v-pagination>
+      <v-pagination
+        v-model="page.currentPage"
+        :length="page.totalPages"
+        :total-visible="7"
+        @input="pageChange"
+      />
     </div>
     <delete-dialog ref="deleteDialog" @push-delete="deleteTag">
       保存されていたツイートのデータが
@@ -89,7 +94,6 @@ export default {
   methods: {
     async fetchData() {
       try {
-        // TODO: await地獄
         const userRes = await this.$axios.get("/api/v1/users/current")
         const { user } = userRes.data
         this.user = user

--- a/app/javascript/pages/Tag.vue
+++ b/app/javascript/pages/Tag.vue
@@ -21,7 +21,7 @@
         v-model="page.currentPage"
         :length="page.totalPages"
         :total-visible="7"
-        @input="pageChange"
+        @input="changePage"
       />
     </div>
     <delete-dialog ref="deleteDialog" @push-delete="deleteTag">

--- a/app/javascript/pages/Top.vue
+++ b/app/javascript/pages/Top.vue
@@ -1,30 +1,11 @@
 <template>
   <ValidationObserver ref="observer">
     <form>
-      <ValidationProvider
-        v-slot="{ errors }"
-        name="Name"
-        rules="required|max:10"
-      >
-        <v-text-field
-          v-model="name"
-          :counter="10"
-          :error-messages="errors"
-          label="Name"
-          required
-        ></v-text-field>
+      <ValidationProvider v-slot="{ errors }" name="Name" rules="required|max:10">
+        <v-text-field v-model="name" :counter="10" :error-messages="errors" label="Name" required />
       </ValidationProvider>
-      <ValidationProvider
-        v-slot="{ errors }"
-        name="email"
-        rules="required|email"
-      >
-        <v-text-field
-          v-model="email"
-          :error-messages="errors"
-          label="E-mail"
-          required
-        ></v-text-field>
+      <ValidationProvider v-slot="{ errors }" name="email" rules="required|email">
+        <v-text-field v-model="email" :error-messages="errors" label="E-mail" required />
       </ValidationProvider>
       <ValidationProvider v-slot="{ errors }" name="select" rules="required">
         <v-select
@@ -34,7 +15,7 @@
           label="Select"
           data-vv-name="select"
           required
-        ></v-select>
+        />
       </ValidationProvider>
       <ValidationProvider v-slot="{ errors }" rules="required" name="checkbox">
         <v-checkbox
@@ -44,7 +25,7 @@
           label="Option"
           type="checkbox"
           required
-        ></v-checkbox>
+        />
       </ValidationProvider>
 
       <v-btn class="mr-4" @click="submit">submit</v-btn>

--- a/app/javascript/plugins/custom-plugins.js
+++ b/app/javascript/plugins/custom-plugins.js
@@ -12,7 +12,6 @@ export default {
   methods: {
     // ページネーション。ページ用コンポーネントでpageオブジェクトを定義しておくこと。
     setPageData(response) {
-      this.page.currentPage = Number(response.headers["current-page"])
       this.page.totalPages = Number(response.headers["total-pages"])
       this.page.requestUrl = response.headers["request-url"]
     }

--- a/app/javascript/plugins/custom-plugins.js
+++ b/app/javascript/plugins/custom-plugins.js
@@ -2,6 +2,7 @@ import goTo from "vuetify/es5/services/goto"
 
 export default {
   mounted() {
+    // ページタイトル。動的なページタイトルはコンポーネントで定義すること
     let { title } = this.$options
     if (title) {
       title = typeof title === "function" ? title.call(this) : title
@@ -9,6 +10,7 @@ export default {
     }
   },
   methods: {
+    // ページネーション。ページ用コンポーネントでpageオブジェクトを定義しておくこと。
     setPageData(response) {
       this.page.currentPage = Number(response.headers["current-page"])
       this.page.totalPages = Number(response.headers["total-pages"])
@@ -16,9 +18,11 @@ export default {
     }
   },
   watch: {
+    // ページネーション。ボタンを押したときに表示するデータを変更する
     async "page.currentPage"(val) {
       goTo(0)
       const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
+      // 増えたらメソッドに切り出す
       const { tweets } = res.data
       this.tweets = tweets
     }

--- a/app/javascript/plugins/custom-plugins.js
+++ b/app/javascript/plugins/custom-plugins.js
@@ -14,14 +14,12 @@ export default {
     setPageData(response) {
       this.page.totalPages = Number(response.headers["total-pages"])
       this.page.requestUrl = response.headers["request-url"]
-    }
-  },
-  watch: {
+    },
     // ページネーション。ボタンを押したときに表示するデータを変更する
-    async "page.currentPage"(val) {
+    async pageChange(val) {
       goTo(0)
       const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
-      // 増えたらメソッドに切り出す
+      // TODO: 増えたらメソッドに切り出す
       const { tweets } = res.data
       this.tweets = tweets
     }

--- a/app/javascript/plugins/custom-plugins.js
+++ b/app/javascript/plugins/custom-plugins.js
@@ -16,7 +16,7 @@ export default {
       this.page.requestUrl = response.headers["request-url"]
     },
     // ページネーション。ボタンを押したときに表示するデータを変更する
-    async pageChange(val) {
+    async changePage(val) {
       goTo(0)
       const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
       // TODO: 増えたらメソッドに切り出す

--- a/app/javascript/plugins/page-title.js
+++ b/app/javascript/plugins/page-title.js
@@ -1,9 +1,26 @@
+import goTo from "vuetify/es5/services/goto"
+
 export default {
   mounted() {
     let { title } = this.$options
     if (title) {
       title = typeof title === "function" ? title.call(this) : title
       document.title = `${title} | Hashlog`
+    }
+  },
+  methods: {
+    setPageData(response) {
+      this.page.currentPage = Number(response.headers["current-page"])
+      this.page.totalPages = Number(response.headers["total-pages"])
+      this.page.requestUrl = response.headers["request-url"]
+    }
+  },
+  watch: {
+    async "page.currentPage"(val) {
+      goTo(0)
+      const res = await this.$axios.get(`${this.page.requestUrl}?page=${val}`)
+      const { tweets } = res.data
+      this.tweets = tweets
     }
   }
 }

--- a/app/jobs/add_tweets_job.rb
+++ b/app/jobs/add_tweets_job.rb
@@ -7,7 +7,7 @@ class AddTweetsJob < ApplicationJob
   end
 
   def perform
-    logger.info("\n#{DateTime.now} : AddTweetsJob")
+    logger.info("\n#{Time.now} : AddTweetsJob")
     registered_tags = RegisteredTag.all.includes(:user, :tag)
     registered_tags.each(&:cron_tweets)
   end

--- a/app/jobs/remind_reply_job.rb
+++ b/app/jobs/remind_reply_job.rb
@@ -8,7 +8,7 @@ class RemindReplyJob < ApplicationJob
   # end
 
   def perform
-    logger.info("\n#{DateTime.now} : RemindReplyJob")
+    logger.info("\n#{Time.now} : RemindReplyJob")
     TwitterAPI::RemindReply.new.call
   end
 end

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -57,7 +57,7 @@ class RegisteredTag < ApplicationRecord
       return
     end
 
-    return if last_tweet.tweeted_at > DateTime.yesterday
+    return if last_tweet.tweeted_at > DateTime.yesterday.to_time
 
     since_id = last_tweet.tweet_id.to_i
     add_tweets(since_id).any? && Rails.logger.info("@#{user.screen_name} の ##{tag.name} にツイートを追加")

--- a/app/models/registered_tag.rb
+++ b/app/models/registered_tag.rb
@@ -57,7 +57,7 @@ class RegisteredTag < ApplicationRecord
       return
     end
 
-    return if last_tweet.tweeted_at > DateTime.yesterday.to_time
+    return if last_tweet.tweeted_at > Time.current.prev_day.beginning_of_day
 
     since_id = last_tweet.tweet_id.to_i
     add_tweets(since_id).any? && Rails.logger.info("@#{user.screen_name} の ##{tag.name} にツイートを追加")

--- a/config/initializers/monkey_patches/pagy.rb
+++ b/config/initializers/monkey_patches/pagy.rb
@@ -1,0 +1,9 @@
+Pagy::Backend.class_eval {
+  private
+  def pagy_headers(pagy)
+    hash = pagy_headers_hash(pagy)
+    hash['Link'] = hash['Link'].map{|rel, link| %(<#{link}>; "#{rel}")}.join(', ')
+    hash['Request-Url'] = request.url.sub(/\?page=(\d+)$/, '?page=')
+    hash
+  end
+}

--- a/config/initializers/monkey_patches/pagy.rb
+++ b/config/initializers/monkey_patches/pagy.rb
@@ -1,9 +1,0 @@
-Pagy::Backend.class_eval {
-  private
-  def pagy_headers(pagy)
-    hash = pagy_headers_hash(pagy)
-    hash['Link'] = hash['Link'].map{|rel, link| %(<#{link}>; "#{rel}")}.join(', ')
-    hash['Request-Url'] = request.url.sub(/\?page=(\d+)$/, '?page=')
-    hash
-  end
-}

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -103,7 +103,7 @@
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-Pagy::VARS[:items] = 10
+# Pagy::VARS[:items] = 10                                   # default
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -103,7 +103,7 @@
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-Pagy::VARS[:items] = 10                                   # default
+Pagy::VARS[:items] = 10
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -103,7 +103,7 @@
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-# Pagy::VARS[:items] = 20                                   # default
+Pagy::VARS[:items] = 10                                   # default
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (3.8.1)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+# Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+# require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default

--- a/spec/factories/registered_tags.rb
+++ b/spec/factories/registered_tags.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :registered_tag do
     user
     tag
+    sequence(:created_at) { |n| Time.current + n.minute }
   end
 
   trait :with_tweets do

--- a/spec/factories/registered_tags.rb
+++ b/spec/factories/registered_tags.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
   trait :with_3_7_days_tweets do
     after(:create) do |registered_tag|
       create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
-      create(:tweet, tweeted_at: DateTime.now.ago(3.day), registered_tag: registered_tag)
+      create(:tweet, tweeted_at: Time.now.ago(3.day), registered_tag: registered_tag)
       create(:tweet, :tweeted_7days_ago, registered_tag: registered_tag)
       registered_tag.fetch_tweets_data!
     end
@@ -30,6 +30,6 @@ FactoryBot.define do
   end
 
   trait :created_yesterday do
-    created_at { DateTime.yesterday }
+    created_at { Time.now.prev_day }
   end
 end

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :tweet do
     sequence(:oembed) { |n| "HTML #{n} <a href=\"https://twitter.com/hashtag/hast_#{n}?src=hash&amp;ref_src=twsrc%5Etfw\">#</a>" }
-    tweeted_at { DateTime.now }
+    tweeted_at { Time.now }
     tweet_id { rand(10 ** 19).to_s }
     registered_tag
   end
 
   trait :tweeted_yesterday do
-    tweeted_at { DateTime.now.ago(1.day) }
+    tweeted_at { Time.now.ago(1.day) }
   end
 
   trait :tweeted_7days_ago do
-    tweeted_at { DateTime.now.ago(7.day) }
+    tweeted_at { Time.now.ago(7.day) }
   end
 end

--- a/spec/jobs/add_tweets_job_spec.rb
+++ b/spec/jobs/add_tweets_job_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe AddTweetsJob, type: :job do
     end
   end
 
+  # TODO: 実行されているが……なぜ通らない
   xdescribe 'AddTweetsJob#perform',
-    vcr: { cassette_name: 'twitter_api/everyday_search/全てのタグのツイートを取得' } do # 実行されているが……なぜ通らない
+    vcr: { cassette_name: 'twitter_api/everyday_search/全てのタグのツイートを取得' } do
     let(:job) { AddTweetsJob.new }
     let(:registered_tag) { create(:registered_tag) }
     it 'ログを出力する' do

--- a/spec/jobs/reminder_reply_job_spec.rb
+++ b/spec/jobs/reminder_reply_job_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RemindReplyJob, type: :job do
     end
   end
 
+  # TODO: 実行されているが……なぜ通らない
   xdescribe 'AddTweetsJob#perform' do
     let(:job) { RemindReplyJob.new }
     let(:remind_reply) { TwitterAPI::RemindReply.new }

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Tweet, type: :model do
   end
 
   describe 'scopes' do
-    let!(:latest_tweet) { create(:tweet, tweeted_at: DateTime.now) }
-    let!(:oldest_tweet) { create(:tweet, tweeted_at: DateTime.yesterday) }
+    let!(:latest_tweet) { create(:tweet, tweeted_at: Time.now) }
+    let!(:oldest_tweet) { create(:tweet, tweeted_at: Time.now.prev_day) }
     describe 'desc' do
       it 'tweeted_atを基準に昇順に並ぶこと' do
         expect(Tweet.desc.first).to eq latest_tweet

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe 'RegisteredTags', type: :request do
     # latest_registered_tagの場所がおかしいのは、作成順に並べるため
     # 実際は作成日が前後することはない
     # https://ddnexus.github.io/pagy/extras/array.html
-    let!(:oldest_registered_tag) { create(:registered_tag, :created_yesterday) }
+    let(:oldest_registered_tag) { RegisteredTag.asc.first }
+    let(:latest_registered_tag) { RegisteredTag.asc.last }
     let(:registered_tags) { RegisteredTag.asc }
     let(:tags_json) { json['registeredTags'] }
     before do
       create_list(:registered_tag, 50)
       get '/api/v1/registered_tags'
     end
-    let!(:latest_registered_tag) { create(:registered_tag, created_at: Date.tomorrow) }
     describe 'pagy' do
       it 'pageクエリがないとき 20件返す' do
         expect(tags_json.length).to eq 20
@@ -40,6 +40,7 @@ RSpec.describe 'RegisteredTags', type: :request do
       end
     end
     it '降順に並ぶ（最古のregistered_tagが最初になる）' do
+      
       expect(tags_json.first['id']).to eq oldest_registered_tag.id
     end
     it '降順に並ぶ（最新のregistered_tagが最後になる）' do

--- a/spec/requests/api/v1/registered_tags_spec.rb
+++ b/spec/requests/api/v1/registered_tags_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'RegisteredTags', type: :request do
   describe 'GET /api/v1/registered_tags' do
-    let!(:latest_registered_tag) { create(:registered_tag, created_at: Date.tomorrow) }
+    # latest_registered_tagの場所がおかしいのは、作成順に並べるため
+    # 実際は作成日が前後することはない
+    # https://ddnexus.github.io/pagy/extras/array.html
     let!(:oldest_registered_tag) { create(:registered_tag, :created_yesterday) }
     let(:registered_tags) { RegisteredTag.asc }
     let(:tags_json) { json['registeredTags'] }
@@ -8,6 +10,7 @@ RSpec.describe 'RegisteredTags', type: :request do
       create_list(:registered_tag, 50)
       get '/api/v1/registered_tags'
     end
+    let!(:latest_registered_tag) { create(:registered_tag, created_at: Date.tomorrow) }
     describe 'pagy' do
       it 'pageクエリがないとき 20件返す' do
         expect(tags_json.length).to eq 20

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -3,14 +3,22 @@ RSpec.describe 'Tags', type: :request do
     let(:tags) { Tag.all }
     let(:tags_json) { json['tags'] }
     before do
-      create_list(:registered_tag, 3)
+      create_list(:registered_tag, 50)
       get '/api/v1/tags'
+    end
+    describe 'pagy' do
+      it 'pageクエリがないとき 20件返す' do
+        expect(tags_json.length).to eq 20
+      end
+      it 'page=2のとき 20件返す' do
+        get '/api/v1/tags?page=2'
+        expect(tags_json.length).to eq 20
+      end
     end
     it '200 OKを返す' do
       expect(response.status).to eq 200
     end
     it 'Tag.allのJSONを返す' do
-      expect(tags_json.length).to eq 3
       tags_json.zip(tags).each do |tag_json, tag|
         expect(tag_json).to eq({
           'id' => tag.id,

--- a/spec/requests/api/v1/tweets_spec.rb
+++ b/spec/requests/api/v1/tweets_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Tweets', type: :request do
   describe 'GET /api/v1/registered_tags/:registered_tag_id/tweets' do
-    let(:registered_tag) { create(:registered_tag, :with_tweets) }
+    let(:registered_tag) { create(:registered_tag) }
     let(:tweets_json) { json['tweets'] }
     let(:tweets) { registered_tag.tweets.desc }
     let!(:latest_registered_tweet) {
@@ -10,14 +10,23 @@ RSpec.describe 'Tweets', type: :request do
       create(:tweet, :tweeted_yesterday, registered_tag: registered_tag)
     }
     before do
-      create_list(:tweet, 3)
+      create_list(:tweet, 30, registered_tag: registered_tag)
       get "/api/v1/registered_tags/#{registered_tag.id}/tweets"
+    end
+    describe 'pagy' do
+      it 'pageクエリがないとき 10件返す' do
+        expect(tweets_json.length).to eq 10
+      end
+      it 'page=2のとき 10件返す' do
+        get "/api/v1/registered_tags/#{registered_tag.id}/tweets?page=2"
+        expect(tweets_json.length).to eq 10
+      end
     end
     it '200 OKを返す' do
       expect(response.status).to eq 200
     end
     it 'RegisteredTag.find(params[:registered_tag_id]).tweets.descのJSONを返す' do
-      expect(tweets_json.length).to eq 5
+      expect(tweets_json.length).to eq 10
       tweets_json.zip(tweets).each do |tweet_json, tweet|
         expect(tweet_json).to eq({
           'id' => tweet.id,
@@ -27,8 +36,11 @@ RSpec.describe 'Tweets', type: :request do
         })
       end
     end
-    it 'tweetsが昇順に並ぶ' do
+    it 'tweetsが昇順に並ぶ（最新のtweetが最初になる）' do
       expect(tweets_json.first['id']).to eq latest_registered_tweet.id
+    end
+    it 'tweetsが昇順に並ぶ（最古のtweetが最後になる）' do
+      get "/api/v1/registered_tags/#{registered_tag.id}/tweets?page=4"
       expect(tweets_json.last['id']).to eq oldest_registered_tweet.id
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -3,14 +3,22 @@ RSpec.describe 'Users', type: :request do
     let(:users) { User.all }
     let(:users_json) { json['users'] }
     before do
-      create_list(:user, 3)
+      create_list(:user, 50)
       get '/api/v1/users'
+    end
+    describe 'pagy' do
+      it 'pageクエリがないとき 10件返す' do
+        expect(users_json.length).to eq 20
+      end
+      it 'page=2のとき 10件返す' do
+        get '/api/v1/users?page=2'
+        expect(users_json.length).to eq 20
+      end
     end
     it '200 OKを返す' do
       expect(response.status).to eq 200
     end
     it 'User.allのJSONを返す' do
-      expect(users_json.length).to eq 3
       users_json.zip(users).each do |user_json, user|
         expect(user_json).to eq({
           'uuid' => user.uuid,

--- a/spec/services/twitter_api_spec.rb
+++ b/spec/services/twitter_api_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe TwitterAPI do
         expect(remind_reply).not_to receive(:send_tweet).with(remind_0_tag)
         remind_reply.call
       end
-      it 'remind_dayが3で最終ツイートが3日前のtagに対してsend_tweetメソッドを実行しない' do
-        remind_3_last_tweet_3_tag = create(:registered_tag, remind_day: 3)
-        create(:tweet, tweeted_at: DateTime.now.ago(3.day), registered_tag: remind_3_last_tweet_3_tag)
-        expect(remind_reply).not_to receive(:send_tweet).with(remind_3_last_tweet_3_tag)
+      it 'remind_dayが7で最終ツイートが7日前のtagに対してsend_tweetメソッドを実行しない' do
+        remind_7_last_tweet_7_tag = create(:registered_tag, remind_day: 7)
+        create(:tweet, :tweeted_7days_ago, registered_tag: remind_7_last_tweet_7_tag)
+        expect(remind_reply).not_to receive(:send_tweet).with(remind_7_last_tweet_7_tag)
         remind_reply.call
       end
-      it 'remind_dayが2で最終ツイートが3日前のtagに対してsend_tweetメソッドを実行する' do
-        remind_2_last_tweet_3_tag = create(:registered_tag, remind_day: 2)
-        create(:tweet, tweeted_at: DateTime.now.ago(3.day), registered_tag: remind_2_last_tweet_3_tag)
-        expect(remind_reply).to receive(:send_tweet).with(remind_2_last_tweet_3_tag).once
+      it 'remind_dayが6で最終ツイートが7日前のtagに対してsend_tweetメソッドを実行する' do
+        remind_6_last_tweet_7_tag = create(:registered_tag, remind_day: 6)
+        create(:tweet, :tweeted_7days_ago, registered_tag: remind_6_last_tweet_7_tag)
+        expect(remind_reply).to receive(:send_tweet).with(remind_6_last_tweet_7_tag).once
         remind_reply.call
       end
     end


### PR DESCRIPTION
## 概要
close #77

[![Image from Gyazo](https://i.gyazo.com/4a27a425dbb1ad83bf0125d75737eb05.gif)](https://gyazo.com/4a27a425dbb1ad83bf0125d75737eb05)
- ページネーションの導入
  - 動画では3件ずつだが、実際はTweetは10件取得する
  - Tweet以外は20件取得
- フロント側はVuetifyのコンポーネントを利用

## 使用gemや外部ツール
- Pagy

早くて軽いということなので導入

## 見てほしい点

```
response.headers.merge!({ 'Request-Url' => request.url.sub(/\?page=\d+$/, '') })
```

という処理を入れたかったので、Pagyにモンキーパッチを当てようと思った（オープンクラスというやつ？）のですが、認識？されなかったため、とりあえずBaseControllerに書いています。

https://github.com/aiandroxA/hashlog/pull/84/files#diff-c6f886abf293c9da74155ff8ccfeab50
↑コードだけ置いているので、見ていただければと思います。
（`class_eval`の理解がいまひとつできていないです……）
ちなみに、`class_eval`を`module_eval`にしてもだめでした。